### PR TITLE
Single line for <pre> tags

### DIFF
--- a/scenarios/mono-to-micro-part-2/04-service-to-service-call.md
+++ b/scenarios/mono-to-micro-part-2/04-service-to-service-call.md
@@ -55,8 +55,7 @@ called [HoverFly](http://hoverfly.io) and particular it's capability to simulate
 to add a `ClassRule` that will simulate all calls to inventory. Click **Copy To Editor** to insert the
 code at the `//TODO: Add ClassRule for HoverFly Inventory simulation` marker:
 
-<pre class="file" data-filename="src/test/java/com/redhat/coolstore/service/CatalogEndpointTest.java"
-data-target="insert" data-marker="//TODO: Add ClassRule for HoverFly Inventory simulation">
+<pre class="file" data-filename="src/test/java/com/redhat/coolstore/service/CatalogEndpointTest.java" data-target="insert" data-marker="//TODO: Add ClassRule for HoverFly Inventory simulation">
 @ClassRule
 public static HoverflyRule hoverflyRule = HoverflyRule.inSimulationMode(dsl(
         service("inventory:8080")


### PR DESCRIPTION
Setting the <pre> tag to a single line will ensure that appropriate Markdown is generated.